### PR TITLE
make sure that we always wrap the local storage

### DIFF
--- a/lib/lockingwrapper.php
+++ b/lib/lockingwrapper.php
@@ -200,7 +200,7 @@ class LockingWrapper extends Wrapper {
 			/**
 			 * @var Storage $storage
 			 */
-			if ($storage instanceof Storage && $storage->isLocal() && !$storage->instanceOfStorage('\OC\Files\Storage\MappedLocal')) {
+			if ($storage->instanceOfStorage('OC\Files\Storage\Local') && !$storage->instanceOfStorage('\OC\Files\Storage\MappedLocal')) {
 				return new LockingWrapper(array('storage' => $storage));
 			} else {
 				return $storage;


### PR DESCRIPTION
Check if storage is a instance of OC\Files\Storage\Local. $storage->isLocal() doesn't work if encryption is enabled because encryption will always return false. (see discussion here: https://github.com/owncloud/core/issues/15848)

fix https://github.com/owncloud/core/issues/16586

cc @PVince81 @icewind1991 @DeepDiver1975 
